### PR TITLE
refinement: extract options dsl.

### DIFF
--- a/lib/poto/file_repository/dsl.rb
+++ b/lib/poto/file_repository/dsl.rb
@@ -1,0 +1,25 @@
+module Poto
+  module FileRepository
+    class Proxy
+      module DSL
+        module ClassMethods
+          def option(name)
+            define_method(name) do |value|
+              tap do
+                options[name] = value
+              end
+            end
+          end
+        end
+
+        def self.included(base)
+          base.extend(ClassMethods)
+        end
+
+        def options
+          @__options ||= {}
+        end
+      end
+    end
+  end
+end

--- a/lib/poto/file_repository/proxy.rb
+++ b/lib/poto/file_repository/proxy.rb
@@ -1,6 +1,14 @@
+require "poto/file_repository/dsl"
+
 module Poto
   module FileRepository
     class Proxy
+      include DSL
+
+      option :per_page
+      option :page
+      option :prefix
+
       attr_reader :backend
 
       def initialize(backend)
@@ -12,25 +20,7 @@ module Poto
       end
 
       def all
-        backend.all(prefix: @prefix, page: @page, per_page: @per_page)
-      end
-
-      def page(page)
-        tap do |proxy|
-          @page = page
-        end
-      end
-
-      def per_page(per_page)
-        tap do |proxy|
-          @per_page = per_page
-        end
-      end
-
-      def prefix(prefix)
-        tap do |proxy|
-          @prefix = prefix
-        end
+        backend.all(options)
       end
     end
   end


### PR DESCRIPTION
Spiked this:

``` ruby
require "minitest/autorun"

class Proxy
  module DSL
    module ClassMethods
      def option(name)
        define_method(name) do |value|
          tap do
            options[name] = value
          end
        end
      end
    end

    def self.included(base)
      base.extend(ClassMethods)
    end

    def options
      @__options ||= {}
    end
  end

  include DSL

  option :per_page
  option :page
end

describe Proxy::DSL do
  before do
    @proxy = Proxy.new
  end

  it "#page" do
    @proxy.page(2).options.must_equal(page: 2)
    @proxy.page(2).per_page(25).options.must_equal(page: 2, per_page: 25)
  end
end
```
